### PR TITLE
Fix handling of Next.js route params

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -18,31 +18,16 @@ export const metadata: Metadata = {
   description: "Yosefa Ferdianto's Portfolio Page",
 };
 
-export default async function RootLayout({children, params }: { children: React.ReactNode; params: Promise<{ locale: string }> }) {
-  const { locale } = await params;
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
   return (
-    <html lang={`${locale}`}>
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+    <html lang="en">
+      <body className={`${geistSans.variable} ${geistMono.variable} antialiased`}>
         {children}
       </body>
     </html>
   );
 }
-
-// export default function RootLayout({
-//   children,
-// }: Readonly<{
-//   children: React.ReactNode;
-// }>) {
-//   return (
-//     <html lang="en">
-//       <body
-//         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-//       >
-//         {children}
-//       </body>
-//     </html>
-//   );
-// }

--- a/app/projects/[slug]/page.tsx
+++ b/app/projects/[slug]/page.tsx
@@ -14,12 +14,11 @@ export async function generateStaticParams() {
 }
 
 interface PageProps {
-  params: Promise<{ slug: string }>;
+  params: { slug: string };
 }
 
-export default async function ProjectPage({ params }: PageProps) {
-  const resolvedParams = await params;
-  const project = projects.find((p) => p.id === resolvedParams.slug);
+export default function ProjectPage({ params }: PageProps) {
+  const project = projects.find((p) => p.id === params.slug);
 
     if (!project) {
         notFound();


### PR DESCRIPTION
## Summary
- simplify RootLayout to remove awaited params and use static language
- accept synchronous params for dynamic project pages to avoid runtime errors

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6898ad57d4108326966540c3d3b543ca