### PR TITLE
feat: add profile link to home page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -53,6 +53,14 @@ const Page = () => {
     return (
         <div className="min-h-screen bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50">
             <div className="container mx-auto px-4 py-16 space-y-12">
+                <a
+                    href="https://yosefa.my.id"
+                    className="block text-center text-blue-600 hover:text-blue-800 font-semibold"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                >
+                    Visit my profile
+                </a>
                 {/* Header Section */}
                 <header className="text-center space-y-6 animate-fade-in">
                     <h1 className="text-6xl font-bold bg-gradient-to-r from-blue-600 via-indigo-600 to-purple-600 text-transparent bg-clip-text">


### PR DESCRIPTION
## Summary
- add link to external profile page at the top of the home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: next: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/react-router-dom)*

------
https://chatgpt.com/codex/tasks/task_e_6898b0183f3c8326bf0901e7f18ca92c